### PR TITLE
Store args on stack.

### DIFF
--- a/src/vm/array.rs
+++ b/src/vm/array.rs
@@ -35,7 +35,7 @@ pub fn init_array(globals: &mut Globals) -> ClassRef {
 fn array_new(
     vm: &mut VM,
     _receiver: PackedValue,
-    args: Vec<PackedValue>,
+    args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     let array_vec = match args.len() {
@@ -64,14 +64,14 @@ fn array_new(
 fn array_push(
     vm: &mut VM,
     receiver: PackedValue,
-    args: Vec<PackedValue>,
+    args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     let mut aref = receiver
         .as_array()
         .ok_or(vm.error_nomethod("Receiver must be an array."))?;
-    for arg in args {
-        aref.elements.push(arg);
+    for arg in args.iter() {
+        aref.elements.push(arg.clone());
     }
     Ok(receiver)
 }
@@ -79,7 +79,7 @@ fn array_push(
 fn array_pop(
     vm: &mut VM,
     receiver: PackedValue,
-    _args: Vec<PackedValue>,
+    _args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     let mut aref = receiver
@@ -92,7 +92,7 @@ fn array_pop(
 fn array_length(
     vm: &mut VM,
     receiver: PackedValue,
-    _args: Vec<PackedValue>,
+    _args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     let aref = receiver

--- a/src/vm/builtin.rs
+++ b/src/vm/builtin.rs
@@ -14,7 +14,7 @@ impl Builtin {
         fn builtin_puts(
             vm: &mut VM,
             _receiver: PackedValue,
-            args: Vec<PackedValue>,
+            args: VecArray,
             _block: Option<MethodRef>,
         ) -> VMResult {
             fn flatten(vm: &VM, val: PackedValue) {
@@ -27,8 +27,8 @@ impl Builtin {
                     }
                 }
             }
-            for arg in args {
-                flatten(vm, arg);
+            for arg in args.iter() {
+                flatten(vm, arg.clone());
             }
             Ok(PackedValue::nil())
         }
@@ -37,16 +37,16 @@ impl Builtin {
         fn builtin_print(
             vm: &mut VM,
             _receiver: PackedValue,
-            args: Vec<PackedValue>,
+            args: VecArray,
             _block: Option<MethodRef>,
         ) -> VMResult {
-            for arg in args {
+            for arg in args.iter() {
                 if let Value::Char(ch) = arg.unpack() {
                     let v = [ch];
                     use std::io::{self, Write};
                     io::stdout().write(&v).unwrap();
                 } else {
-                    print!("{}", vm.val_to_s(arg));
+                    print!("{}", vm.val_to_s(arg.clone()));
                 }
             }
             Ok(PackedValue::nil())
@@ -56,7 +56,7 @@ impl Builtin {
         fn builtin_assert(
             vm: &mut VM,
             _receiver: PackedValue,
-            args: Vec<PackedValue>,
+            args: VecArray,
             _block: Option<MethodRef>,
         ) -> VMResult {
             if args.len() != 2 {
@@ -78,7 +78,7 @@ impl Builtin {
         fn builtin_block_given(
             vm: &mut VM,
             _receiver: PackedValue,
-            _args: Vec<PackedValue>,
+            _args: VecArray,
             _block: Option<MethodRef>,
         ) -> VMResult {
             Ok(PackedValue::bool(vm.context().block.is_some()))

--- a/src/vm/class.rs
+++ b/src/vm/class.rs
@@ -57,7 +57,7 @@ pub fn init_class(globals: &mut Globals) -> ClassRef {
 fn class_superclass(
     vm: &mut VM,
     receiver: PackedValue,
-    _args: Vec<PackedValue>,
+    _args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     match receiver.as_class() {
@@ -73,7 +73,7 @@ fn class_superclass(
 fn class_new(
     vm: &mut VM,
     receiver: PackedValue,
-    args: Vec<PackedValue>,
+    args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     match receiver.as_class() {
@@ -95,12 +95,12 @@ fn class_new(
 fn class_attr(
     vm: &mut VM,
     receiver: PackedValue,
-    args: Vec<PackedValue>,
+    args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     match receiver.as_class() {
         Some(classref) => {
-            for arg in args {
+            for arg in args.iter() {
                 if arg.is_packed_symbol() {
                     let id = arg.as_packed_symbol();
                     let info = MethodInfo::AttrReader { id };

--- a/src/vm/context.rs
+++ b/src/vm/context.rs
@@ -60,7 +60,7 @@ impl Context {
         }
     }
 
-    pub fn set_arguments(&mut self, args: Vec<PackedValue>) {
+    pub fn set_arguments(&mut self, args: VecArray) {
         let arg_len = std::cmp::min(args.len(), self.iseq_ref.params.len());
         if arg_len <= LVAR_ARRAY_SIZE {
             for i in 0..arg_len {

--- a/src/vm/integer.rs
+++ b/src/vm/integer.rs
@@ -16,7 +16,7 @@ pub fn init_integer(globals: &mut Globals) -> ClassRef {
 fn integer_times(
     vm: &mut VM,
     receiver: PackedValue,
-    _args: Vec<PackedValue>,
+    _args: VecArray,
     block: Option<MethodRef>,
 ) -> VMResult {
     let num = receiver.as_fixnum().unwrap();
@@ -35,7 +35,7 @@ fn integer_times(
                     self_value,
                     iseq,
                     Some(context),
-                    vec![PackedValue::fixnum(i)],
+                    VecArray::new1(PackedValue::fixnum(i)),
                     None,
                 )?;
                 vm.exec_stack.pop().unwrap();
@@ -49,7 +49,7 @@ fn integer_times(
 fn integer_chr(
     _vm: &mut VM,
     receiver: PackedValue,
-    _args: Vec<PackedValue>,
+    _args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     let num = receiver.as_fixnum().unwrap();

--- a/src/vm/method.rs
+++ b/src/vm/method.rs
@@ -1,11 +1,7 @@
 use crate::vm::*;
 
-pub type BuiltinFunc = fn(
-    vm: &mut VM,
-    receiver: PackedValue,
-    args: Vec<PackedValue>,
-    block: Option<MethodRef>,
-) -> VMResult;
+pub type BuiltinFunc =
+    fn(vm: &mut VM, receiver: PackedValue, args: VecArray, block: Option<MethodRef>) -> VMResult;
 
 pub type MethodTable = HashMap<IdentId, MethodRef>;
 

--- a/src/vm/object.rs
+++ b/src/vm/object.rs
@@ -99,7 +99,7 @@ pub fn init_object(globals: &mut Globals) {
 fn object_class(
     vm: &mut VM,
     receiver: PackedValue,
-    _args: Vec<PackedValue>,
+    _args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     let class = receiver.get_class(&vm.globals);

--- a/src/vm/procobj.rs
+++ b/src/vm/procobj.rs
@@ -32,7 +32,7 @@ pub fn init_proc(globals: &mut Globals) -> ClassRef {
 fn proc_new(
     vm: &mut VM,
     _receiver: PackedValue,
-    _args: Vec<PackedValue>,
+    _args: VecArray,
     block: Option<MethodRef>,
 ) -> VMResult {
     let procobj = match block {
@@ -50,7 +50,7 @@ fn proc_new(
 fn proc_call(
     vm: &mut VM,
     receiver: PackedValue,
-    args: Vec<PackedValue>,
+    args: VecArray,
     _block: Option<MethodRef>,
 ) -> VMResult {
     let pref = match receiver.as_proc() {

--- a/tests/block.rb
+++ b/tests/block.rb
@@ -1,3 +1,7 @@
 y = 0
-10000.times do |x| 1000.times do |x| y = y + 1 end end
+10000.times do |x|
+    1000.times do |x|
+        y = y + 1
+    end
+end
 puts y


### PR DESCRIPTION
Introduce VecArray.
Place the arguments for method call on stack rather than heap.