### PR TITLE
Add Object#methods and Object#singleton_methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,12 +269,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -450,6 +466,7 @@ dependencies = [
  "divrem",
  "fancy-regex",
  "fxhash",
+ "indexmap",
  "rand",
  "regex",
  "region",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ dirs = "3.0.1"
 smallvec = "1.5.0"
 arraystring = "0.3.0"
 region = "2.2.0"
+indexmap = "1.6.2"
 
 [profile.release]
 debug = false

--- a/src/builtin/module.rs
+++ b/src/builtin/module.rs
@@ -178,7 +178,7 @@ fn const_get(_: &mut VM, self_val: Value, args: &Args) -> VMResult {
     Ok(val)
 }
 
-fn instance_methods(_: &mut VM, self_val: Value, args: &Args) -> VMResult {
+pub(crate) fn instance_methods(_: &mut VM, self_val: Value, args: &Args) -> VMResult {
     args.check_args_range(0, 1)?;
     let mut module = self_val.into_module();
     let inherited_too = args.len() == 0 || args[0].to_bool();
@@ -192,18 +192,11 @@ fn instance_methods(_: &mut VM, self_val: Value, args: &Args) -> VMResult {
             Ok(Value::array_from(v))
         }
         true => {
-            let mut v = std::collections::HashSet::new();
+            let mut v = FxIndexSet::default();
             loop {
-                v = v
-                    .union(
-                        &module
-                            .method_table()
-                            .keys()
-                            .map(|k| Value::symbol(*k))
-                            .collect(),
-                    )
-                    .cloned()
-                    .collect();
+                for k in module.method_table().keys() {
+                    v.insert(Value::symbol(*k));
+                }
                 match module.upper() {
                     None => break,
                     Some(upper) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate fxhash;
 extern crate region;
 extern crate smallvec;
 pub use fxhash::FxHashMap;
+pub use indexmap;
 pub mod alloc;
 pub mod builtin;
 pub mod coroutine;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,8 @@ use core::ptr::NonNull;
 use std::path::PathBuf;
 use term_size;
 
+pub type FxIndexSet<T> = indexmap::IndexSet<T, fxhash::FxBuildHasher>;
+
 #[derive(Debug, Clone)]
 pub struct Annot<T> {
     pub kind: T,


### PR DESCRIPTION
This adds a dependency on the `indexmap` crate since we need a way for iteration order to match insertion order.  I suspect it will be used more since that's how MRI's `Hash` works.